### PR TITLE
fix timeSpan implementation

### DIFF
--- a/src/timeSpan.ts
+++ b/src/timeSpan.ts
@@ -10,7 +10,7 @@ export const timeSpan = () => {
   };
 
   const returnValue = () => end('milliseconds');
-  returnValue.rounded = () => Math.round(end('nanoseconds'));
+  returnValue.rounded = () => Math.round(end('milliseconds'));
   returnValue.seconds = () => end('seconds');
   returnValue.nanoseconds = () => end('nanoseconds');
 

--- a/src/timeSpan.ts
+++ b/src/timeSpan.ts
@@ -1,11 +1,16 @@
-import convertHrtime from 'convert-hrtime';
+import convertHrtime, { HighResolutionTime } from 'convert-hrtime';
 
 export const timeSpan = () => {
-  const start = process.hrtime();
-  const end = (type) => convertHrtime(process.hrtime(start))[type];
+  const start = process.hrtime.bigint();
+  const end = (timeMeasure: keyof HighResolutionTime) => {
+    const diff = process.hrtime.bigint() - start;
+    return Number(convertHrtime(
+      diff
+    )[timeMeasure])
+  };
 
   const returnValue = () => end('milliseconds');
-  returnValue.rounded = () => Math.round(end('milliseconds'));
+  returnValue.rounded = () => Math.round(end('nanoseconds'));
   returnValue.seconds = () => end('seconds');
   returnValue.nanoseconds = () => end('nanoseconds');
 


### PR DESCRIPTION
This PR resolves issue #5, which was caused by an issue in the convertHrtime function. Specifically, the function expected the difference between the start time but received a array with seconds and nanoseconds