### PR TITLE
Follow the guidelines for CI/CD

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Dependency install
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Test
         run: yarn test
@@ -44,7 +44,7 @@ jobs:
       
       
       - name: Dependency install
-        run: yarn
+        run: yarn install --frozen-lockfile
       
       - name: Compile
         run: yarn build


### PR DESCRIPTION
In a CI/CD environment we need to use the `--frozen-lockfile` to download your deps.

[Read more here](https://classic.yarnpkg.com/lang/en/docs/cli/install/)