### PR TITLE
fix: error when trying to save mock request file that doesn't exist

### DIFF
--- a/src/apiCache.ts
+++ b/src/apiCache.ts
@@ -10,11 +10,11 @@ import { debugConsole } from './debugConsole';
 import { getCurl } from './getCurl';
 
 const readFile = util.promisify(fs.readFile);
-// const writeFile = util.promisify(fs.writeFile);
+const writeFile = util.promisify(fs.writeFile);
 const writeFileAtomic = util.promisify(writeFileAtomicCallback);
+
 const cwd = process.cwd();
 const dirPath = 'mock-requests.json';
-
 const output = path.join(cwd, dirPath);
 
 export const getRequestKey = (init: RequestInfo, options: RequestInit) => {
@@ -45,14 +45,15 @@ export const saveRequestMock = async (
   let dataString = null;
 
   try {
-    dataString = await readFile(output, 'utf8');
-
-    console.log(dataString);
-  } catch (err) {
-    if (err && err.code !== 'ENOENT') {
-      // eslint-disable-next-line
-      console.log({ err });
+    if (fs.existsSync(output)) {
+      dataString = await readFile(output, 'utf8');
+      console.log(dataString);
+    } else {
+      await writeFile(output, '');
     }
+  } catch (err) {
+    // eslint-disable-next-line
+    console.log({ err });
   }
 
   try {

--- a/src/apiCache.ts
+++ b/src/apiCache.ts
@@ -49,8 +49,10 @@ export const saveRequestMock = async (
 
     console.log(dataString);
   } catch (err) {
-    // eslint-disable-next-line
-    console.log({ err });
+    if (err && err.code !== 'ENOENT') {
+      // eslint-disable-next-line
+      console.log({ err });
+    }
   }
 
   try {


### PR DESCRIPTION
# Description

As mentioned in issue #10, if the file "mock-requests.json" does not exist and you run the command "WRITE_MOCK=true yarn es scripts/test.ts", an error message will be shown, however, the file is created in any case

# Changes

- Add a simple check inside the try-catch block to determine if the error is due to the file not existing.

# Related Issues

* Closes #10